### PR TITLE
fixed mismatching configured amperage on dps5015

### DIFF
--- a/rdserial/dps/__init__.py
+++ b/rdserial/dps/__init__.py
@@ -35,7 +35,7 @@ class DPSDeviceState:
             'setting_amps': {
                 'description': 'Amperage setting',
                 'register': 0x01,
-                **_simple_int(1000),
+                **_simple_int(100),
             },
             'volts': {
                 'description': 'Output volts',


### PR DESCRIPTION
This PR closes #8
Allthough i am unable to test on different devices as i only have a DPS5015.