### PR TITLE
maybe just a typo..

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The RDTech (RuiDeng) [UM24C](https://www.aliexpress.com/item/RD-UM24-UM24C-for-A
 
 ## Setup
 
-rdumtool requires Python 3, and [PyBluez](https://pypi.org/project/PyBluez/) and/or [pyserial](https://pypi.org/project/pyserial/) modules.  Installation varies by operating system, but on Debian/Ubuntu, these are available via the python3-pybluez and python3-serial packages.
+rdumtool requires Python 3, and [PyBluez](https://pypi.org/project/PyBluez/) and/or [pyserial](https://pypi.org/project/pyserial/) modules.  Installation varies by operating system, but on Debian/Ubuntu, these are available via the python3-bluez and python3-serial packages.
+Also install python3-setuptools (at least at Kubuntu noble 24.4)
 
 To install rdumtool:
 


### PR DESCRIPTION
Hi, i am Simon, i am new to github, just wanted to ask if the mentioned python3-pybluez at the setup-section (readme) meant to be python3-bluez (couldnt find the mentioned package at kubuntu-linux-stable atm).

and also I cloned the git-repository, tried to execute, got an error stating that some setuptools are missing.

`Traceback (most recent call last):
  File "/home/simon/files/Programme-why-ever/USB-multimeter_ruideng-bluetooth/rdumtool/./setup.py", line 5, in <module>
    from setuptools import setup, find_packages
ModuleNotFoundError: No module named 'setuptools'
`

so I installed:

`aptitude install python3-setuptools`

I Hope this contact isnt received-unpolitely, didnt know how else to ask this question, thankyou for coding this software! I am really curious to use it (and I cannot code myself like this).

sincerely yours simon
(is this pull request publicially visible? dude.. i am such a noob :-D)

well, hard to mention something (notify someone) ask a question.
now i Created a fork which is stupid, because I just wanted to ask if something is a typo,.. 